### PR TITLE
Publish ImageService in Dockerfile and correct project structure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,6 +93,15 @@ RUN mkdir -p \
 RUN touch /var/log/imaging.log && \
     chown serviceuser:serviceuser /var/log/imaging.log
 
+# Copy ImagingService.dll to /opt/imaging-service/
+COPY ImagingService.dll /opt/imaging-service/
+
+# Set the working directory to /opt/imaging-service/
+WORKDIR /opt/imaging-service/
+
+# Run the ImagingService as the entry point
+ENTRYPOINT ["dotnet", "ImagingService.dll"]
+
 # Switch to bash as default shell
 SHELL ["/bin/bash", "-c"]
 CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -90,4 +90,41 @@ For questions or inquiries, please reach out to:
 - .NET 8+  
 - SQL Server / PostgreSQL  
 
+---
+
+## 📦 **ImagingService Deployment**
+
+The `ImagingService` is a core component of SysMaven that handles the imaging and deployment of systems. It is included in the Dockerfile and can be deployed as part of the SysMaven setup.
+
+### **Dockerfile Configuration**
+
+The `Dockerfile` has been updated to include the `ImagingService`. The relevant steps are:
+
+1. Copy `ImagingService.dll` to `/opt/imaging-service/`:
+   ```dockerfile
+   COPY ImagingService.dll /opt/imaging-service/
+   ```
+
+2. Set the working directory to `/opt/imaging-service/`:
+   ```dockerfile
+   WORKDIR /opt/imaging-service/
+   ```
+
+3. Run the `ImagingService` as the entry point:
+   ```dockerfile
+   ENTRYPOINT ["dotnet", "ImagingService.dll"]
+   ```
+
+### **Building and Running the Docker Image**
+
+1. Build the Docker image:
+   ```bash
+   docker build -t sysmaven:latest .
+   ```
+
+2. Run the Docker container:
+   ```bash
+   docker run -d --name sysmaven -p 8080:80 sysmaven:latest
+   ```
+
 Thank you for exploring **SysMaven**! Let's simplify IT together. 🌟


### PR DESCRIPTION
Update the `Dockerfile` and `README.md` to include the `ImagingService`.

* **Dockerfile**
  - Copy `ImagingService.dll` to `/opt/imaging-service/`.
  - Set the working directory to `/opt/imaging-service/`.
  - Run the `ImagingService` as the entry point.

* **README.md**
  - Add a section about the `ImagingService` and its deployment.
  - Include steps for Dockerfile configuration and building/running the Docker image.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/srs-adamr/SysMaven/pull/1?shareId=d9409410-bd7a-4247-af82-d1d33a9c1f64).